### PR TITLE
not show headerfooter when print.

### DIFF
--- a/src/xmlWorksheet.js
+++ b/src/xmlWorksheet.js
@@ -184,6 +184,6 @@ export function makeXworksheet (sheet = new Xworksheet()) {
   headerFooter.oddHeader = '&C&"Times New Roman,Regular"&12&A';
   headerFooter.oddFooter = '&C&"Times New Roman,Regular"&12Page &P';
 
-  sheet.headerFooter = headerFooter;
+  // sheet.headerFooter = headerFooter;
   return sheet;
 }


### PR DESCRIPTION
I user this library to generate xlsx file. When i want to print the xlsx to paper.I saw the header with "sheetname" and footer with "page 1".

what i expected is default not to show the header and footer. I need to modify the xlsx file by hand before i print it.

Maybe you can give user a config item. Many thanks!